### PR TITLE
Fix for Issue 94

### DIFF
--- a/app/source/js/models/PublicUserJobTitle.js
+++ b/app/source/js/models/PublicUserJobTitle.js
@@ -66,17 +66,22 @@ function PublicUserJobTitle(values) {
     this.model.defID(['userID', 'jobTitleID']);
     
     var findMinValue = function(services) {
-        var s = services;
+        var s = services,
+            maxValue = { price: Number.MAX_VALUE };
+
         if (s.length === 0) return null;
-        return s.reduce(function(last, serv) {
-            return (serv.priceRate() && serv.priceRate() < last.price) ? {
+
+        var minValue = s.reduce(function(last, serv) {
+            return ((serv.priceRate() !== null) && serv.priceRate() < last.price) ? {
                 price: serv.priceRate(),
                 unit: serv.priceRateUnit()
-            } : (serv.price() && serv.price() < last.price) ? {
+            } : ((serv.price() !== null) && serv.price() < last.price) ? {
                 price: serv.price(),
                 unit: null
             } : last;
-        }, { price: Number.MAX_VALUE });
+        }, maxValue);
+
+        return minValue === maxValue ? null : minValue;
     };
 
     this.minServiceValue = ko.pureComputed(function() {


### PR DESCRIPTION
fix for #94 

findMinValue was checking for the existence of priceRate and price, but the value 0 is evaluated as false. Services with priceRate or price values of 0 were ignored, and the sentinel value (Number.MAX_VALUE) was being returned. format throws an exception when working on MAX_VALUE. 

The fix compares priceRate and price to null instead. It also prevents the MAX_VALUE from slipping through in cases where all services have a price and priceRate of null. (This shouldn't ever be the case.)