### PR TITLE
serviceprofessionalservices activity now uses shared view model

### DIFF
--- a/app/source/html/activities/serviceProfessionalService.html
+++ b/app/source/html/activities/serviceProfessionalService.html
@@ -31,7 +31,7 @@
                     <h2 class="SectionTitle" data-bind="visible: !$root.isAdditionMode()">
                         <span data-bind="text: group"></span>
                     </h2>
-                    <ul class="TilesList" data-bind="foreach: pricing">
+                    <ul class="TilesList" data-bind="foreach: services">
                         <li>
                             <a href="#" class="ItemTile" data-bind="click: $root.tapService" role="button">
                                 <div class="Tile-marker">
@@ -70,4 +70,4 @@
             </div>
         </div>
     </div> 
-</div> 
+</div>

--- a/app/source/js/viewmodels/ServiceProfessionalService.js
+++ b/app/source/js/viewmodels/ServiceProfessionalService.js
@@ -84,7 +84,7 @@ function ServiceProfessionalServiceViewModel(app) {
             });
         }
         
-        if (!this.isSelectionMode() || !this.loadEmptyPricingTypes()) {
+        if (this.loadEmptyPricingTypes()) {
             // Since the groupsList is built from the existent pricing items
             // if there are no records for some pricing type (or nothing when
             // just created the job title), that types/groups are not included,


### PR DESCRIPTION
Merged the view model in the servicePofessionalServices (SPS) activity with the overlapping implementation in viewmodels/. I removed all common code from the view model in SPS.

The view model in SPS activity now inherits from the shared view model. The shared view model is already used during the service booking process.

I added a flag `loadEmptyPricingTypes`. One difference between the two view models is that the shared view model did not load pricing types unless there were pricings of that type. The view model in SPS activity loaded all pricing types for the service professional. This flag allows the shared view model to either load empty pricing types or not.

I tested this locally by creating, modifying, and deleting pricing types from my professional account (for multiple job titles). I also started the booking process as a client.

@IagoSRL this is a part of #4. But, this code has no dependencies on #4 and can be merged into master pending your review. Please delete the issue4-sps-view-model branch when you merge this.
