### PR TITLE
Client specific offerings on profile

### DIFF
--- a/app/source/html/activities/profile.html
+++ b/app/source/html/activities/profile.html
@@ -81,16 +81,19 @@
                         </div>
 
                         <div id="profile-pricing" data-bind="with: selectedJobTitle">
-                            <h4 class="bold text-muted"><i class="icon ion-social-usd-outline h2"></i> Pricing</h4>
-                            <div class="row" data-bind="foreach: services">
+                            <script type="text/html" id="profile-services-listing-template">
                                 <div class="col-xs-6 panel-content">
                                     <section>
                                         <h5 class="bold margin0b" data-bind="text: name"></h5>
                                         <p class="bold loco-info" data-bind="text: displayedDurationAndPrice"></p>
                                         <article data-bind="visible: description, text: description"></article>
-                                    </section>
+                                  </section>
                                 </div>
-                            </div>
+                            </script>
+                            <h4 class="bold text-muted" data-bind="visible: clientSpecificServices().length > 0"><i class="icon ion-social-usd-outline h2"></i> Pricing Only For You</h4>
+                            <div class="row" data-bind="template: { name: 'profile-services-listing-template', foreach: clientSpecificServices() }"></div>
+                            <h4 class="bold text-muted"><i class="icon ion-social-usd-outline h2"></i> Pricing</h4>
+                            <div class="row" data-bind="template: { name: 'profile-services-listing-template', foreach: publicServices() }"></div>
                         </div>
 
                         <div id="profile-reviews" data-bind="with: selectedJobTitle">

--- a/app/source/js/models/PublicUserJobTitle.js
+++ b/app/source/js/models/PublicUserJobTitle.js
@@ -96,6 +96,18 @@ function PublicUserJobTitle(values) {
             return numeral(price.price).format('$0.00');
         }
     }, this);
+
+    this.clientSpecificServices = function() {
+        return this.services().filter(function(service) {
+            return service.isClientSpecific();
+        });
+    };
+
+    this.publicServices = function() {
+        return this.services().filter(function(service) {
+            return !service.isClientSpecific();
+        });
+    };
 }
 
 module.exports = PublicUserJobTitle;

--- a/app/source/js/models/ServiceProfessionalService.js
+++ b/app/source/js/models/ServiceProfessionalService.js
@@ -32,7 +32,8 @@ function ServiceProfessionalService(values) {
         // Array of integers, IDs of serviceAttributes
         serviceAttributes: [],
         createdDate: null,
-        updatedDate: null
+        updatedDate: null,
+        visibleToClientID: 0
     }, values);
     
     this.model.defID(['serviceProfessionalServiceID']);
@@ -153,6 +154,10 @@ function ServiceProfessionalService(values) {
         else
             return dur || pr;
     }, this);
+
+    this.isClientSpecific = function() {
+        return this.visibleToClientID() > 0;
+    }.bind(this);
 }
 
 module.exports = ServiceProfessionalService;


### PR DESCRIPTION
Pull request for #317 

The API call for provider profile already includes client specific pricing for the logged in caller. This pull request includes PublicUserJobTitle methods to separate client specific pricing from public pricing. (The category _public pricing_ may change in the future.)

There is a line in models/ServiceProfessionalService.js that may conflict with #302 because it is duplicated. I added ``visibleToClientID`` field to the model.