### PR TITLE
Bug S4 scrollToElement param bug fix

### DIFF
--- a/app/source/js/utils/scrollToElement.js
+++ b/app/source/js/utils/scrollToElement.js
@@ -19,6 +19,8 @@ var $ = require('jquery');
 // }
 module.exports = function scrollToElement(el, options) {
     //jshint maxcomplexity:10
+    el = (el instanceof $) ? el : $(el);
+
     var parent = $(el).parent();
 
     var topOffset = options && options.topOffset || 0;


### PR DESCRIPTION
This doesn't have an issue. I discovered it during #318. The scrollToElement documentation says that it accepts a DOM element or a jQuery object target, but the code actually assumes a jQuery object.

The new code wraps the ``el`` in a jquery object if it isn't already wrapped.