### PR TITLE
Give a bit of padding to bottom of profile page.

### DIFF
--- a/app/source/css/activities/profile.styl
+++ b/app/source/css/activities/profile.styl
@@ -103,6 +103,7 @@
 
     .page-wrapper
       background-color #ecf0f1
+      padding-bottom 40px
 
     .form-wrapper
       background-color $loco-common


### PR DESCRIPTION
@joshdanielson hey there, starting small with limited time 😄 but I got the app running so here's something...

Adds `40px` padding bottom to page wrapper on profile as it was getting clipped right after the map BEFORE making it "feel" like there was more content getting hidden:
![image](https://cloud.githubusercontent.com/assets/142403/25599943/e7ec58d6-2e94-11e7-8c1b-e76594cf13a6.png)


Here's AFTER:

![image](https://cloud.githubusercontent.com/assets/142403/25599953/f7537688-2e94-11e7-9379-47f40e1f004b.png)
