### PR TITLE
added job title id to link to profile from job search results page #326

### DIFF
--- a/app/source/html/activities/searchJobTitle.html
+++ b/app/source/html/activities/searchJobTitle.html
@@ -55,7 +55,7 @@
             <div class="ServiceProfessionalResult-actions">         
                 <a href="/profile/" data-bind="attr: {href: '/booking/' + userID() + '/' + jobTitleID()}, visible: !instantBooking()" class="btn btn-primary">Request to book</a> 
                 <a href="/profile/" data-bind="attr: {href: '/booking/' + userID() + '/' + jobTitleID()}, visible: instantBooking()" class="btn btn-primary">Book instantly</a> 
-                <a href="/profile/" data-bind="attr: {href: '/profile/' + userID()}">See profile and reviews</a>
+                <a href="/profile/" data-bind="attr: {href: '/profile/' + userID() + '/' + jobTitleID()}">See profile and reviews</a>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
Fix for #326 

Prior to this fix, the URL in the link to professionals' profile from the job search page did not include the job title. It defaulted to a job title. 

In this case, since we always have a job title id, I added the id to the URL, forcing the profile to show the job title in the profile that was searched for.