### PR TITLE
Is392 optional services overview

### DIFF
--- a/app/source/html/activities/licensesCertificationsForm.html
+++ b/app/source/html/activities/licensesCertificationsForm.html
@@ -1,9 +1,10 @@
 <!-- licensesCertificationsForm activity -->
 <div data-activity="licensesCertificationsForm" class="Boxes-sm animated">
-    <app-inline-user-menu></app-inline-user-menu>
+    <app-inline-user-menu data-bind="visible: !isInOnboarding()"></app-inline-user-menu>
+    <app-onboarding-menu data-bind="visible: isInOnboarding"></app-onboarding-menu>
     <div class="container" data-bind="css: { 'is-loading': isLoading }">
-        <div class="row">   
-            <div class="SubSectionNavBar hidden-xs hidden-sm">
+        <div class="row">
+            <div data-bind="visible: !isInOnboarding()" class="SubSectionNavBar hidden-xs hidden-sm">
                 <ul>
                     <li>
                         <a href="/licensesCertifications/" data-bind="attr: {href: '/licensesCertifications/' + jobTitleID()}">

--- a/app/source/html/activities/marketplaceJobtitles.html
+++ b/app/source/html/activities/marketplaceJobtitles.html
@@ -43,7 +43,8 @@
                             <span class="fa ion ion-clipboard" aria-hidden="true"></span>
                         </div>
                         <div class="Tile-content">
-                            <p>Overview of your <span data-bind="text: jobTitleName"></span> services</p>
+                            <div><span data-bind="text: jobTitleName"></span> listing details</div>
+                            <em>Tell clients about what you do</em>
                         </div>
                     </a></li>
                     <li>

--- a/app/source/html/activities/profile.html
+++ b/app/source/html/activities/profile.html
@@ -6,7 +6,7 @@
     <div class="PageMenu">
         <div class="PageMenu-list hidden-xs">
             <ul>
-                <li><a href="#profile-overview">Overview</a></li>
+                <li data-bind="visible: hasServicesOverview"><a href="#profile-overview">Overview</a></li>
                 <li><a href="#profile-pricing">Pricing</a></li>
                 <li><a href="#profile-reviews">Reviews</a></li>
                 <li><a href="#profile-workphotos">Photos</a></li>
@@ -65,14 +65,21 @@
         <div class="page-wrapper border-top">
             <div class="container">
                 <div class="row">
-                    <!-- overview col-sm-8-->
                     <section class="col-xs-12">
-                        <div id="profile-overview" class="loco-infolight" data-bind="with: selectedJobTitle">
+                        <div id="profile-overview" class="loco-infolight" data-bind="visible: $root.hasServicesOverview, with: selectedJobTitle">
                             <h4 class="bold text-muted"><i class="icon ion-clipboard h2"></i> Overview of services</h4>
-                            <p data-bind="text: intro"></p>
+                            <p data-bind="text: intro, visible: intro().length > 0"></p>
                             <div data-bind="foreach: serviceAttributes().serviceAttributes">
                                 <div class="bold margin10t" data-bind="text: name"></div>
                                 <div data-bind="foreach: serviceAttributes" class="clearfix">
+                                    <div class="col-xs-6 col-md-4 pad5l pad5r">
+                                        <i class="icon ion-android-done"></i> <span data-bind="text: name"></span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div data-bind="visible: serviceAttributes().hasExperienceLevel(), with: serviceAttributes().experienceLevel">
+                                <div class="bold margin10t">Experience</div>
+                                <div class="clearfix">
                                     <div class="col-xs-6 col-md-4 pad5l pad5r">
                                         <i class="icon ion-android-done"></i> <span data-bind="text: name"></span>
                                     </div>

--- a/app/source/html/activities/profile.html
+++ b/app/source/html/activities/profile.html
@@ -68,7 +68,7 @@
                     <section class="col-xs-12">
                         <div id="profile-overview" class="loco-infolight" data-bind="visible: $root.hasServicesOverview, with: selectedJobTitle">
                             <h4 class="bold text-muted"><i class="icon ion-clipboard h2"></i> Overview of services</h4>
-                            <p data-bind="text: intro, visible: intro().length > 0"></p>
+                            <p data-bind="text: intro, visible: hasIntro"></p>
                             <div data-bind="foreach: serviceAttributes().serviceAttributes">
                                 <div class="bold margin10t" data-bind="text: name"></div>
                                 <div data-bind="foreach: serviceAttributes" class="clearfix">

--- a/app/source/html/activities/servicesOverview.html
+++ b/app/source/html/activities/servicesOverview.html
@@ -1,10 +1,9 @@
 <!-- Activity servicesOverview -->
 <div data-activity="servicesOverview" class="Boxes-sm animated">
-    <app-inline-user-menu data-bind="visible: !isInOnboarding()"></app-inline-user-menu>
-    <app-onboarding-menu data-bind="visible: isInOnboarding"></app-onboarding-menu>
+    <app-inline-user-menu></app-inline-user-menu>
     <div class="container">
         <div class="row">
-            <div data-bind="visible: !isInOnboarding()" class="SubSectionNavBar hidden-xs hidden-sm">
+            <div class="SubSectionNavBar hidden-xs hidden-sm">
                 <ul>
                     <li>
                         <a href="/marketplaceJobtitles/" data-bind="attr: {href: '/marketplaceJobtitles/' + jobTitleID()}">
@@ -15,13 +14,12 @@
                 </ul>
             </div>
             <div class="col-md-7 col-sm-reset">
-                <app-onboarding-progress-bar></app-onboarding-progress-bar>
                 <div class="OnboardingValueProp">
                     <div class="Icon-container">
                         <span class="Tile-icon fa ion ion-clipboard" aria-hidden="true"></span>
                     </div>
                     <span class="Tile-content">
-                        <h2><span data-bind="visible: isInOnboarding()">Describe your <span data-bind="text: jobTitleName"></span> services</span><span data-bind="visible: !isInOnboarding()"><span data-bind="text: jobTitleName"></span> services description</span></h2>
+                        <h2>Describe your <span data-bind="text: jobTitleName"></span> services</h2>
                         <p>Tell clients what your work is all about–they want to know!</p>
                     </span>
                 </div>

--- a/app/source/js/activities/profile.js
+++ b/app/source/js/activities/profile.js
@@ -192,10 +192,10 @@ function ViewModel(app) {
 
     this.hasServicesOverview = ko.pureComputed(function() {
         var jobTitle = this.user() && this.user().selectedJobTitle(),
-            intro = jobTitle && jobTitle.intro(),
+            hasIntro = jobTitle && jobTitle.hasIntro(),
             hasAttributes = jobTitle && jobTitle.serviceAttributes().hasAttributes();
 
-        return intro || hasAttributes;
+        return hasIntro || hasAttributes;
     }, this);
 }
 

--- a/app/source/js/activities/profile.js
+++ b/app/source/js/activities/profile.js
@@ -189,6 +189,14 @@ function ViewModel(app) {
         if (!u) return '';
         return '#!inbox/new/' + u.profile().userID();
     }, this);
+
+    this.hasServicesOverview = ko.pureComputed(function() {
+        var jobTitle = this.user() && this.user().selectedJobTitle(),
+            intro = jobTitle && jobTitle.intro(),
+            hasAttributes = jobTitle && jobTitle.serviceAttributes().hasAttributes();
+
+        return intro || hasAttributes;
+    }, this);
 }
 
 var PublicUserReview = require('../models/PublicUserReview');

--- a/app/source/js/activities/servicesOverview.js
+++ b/app/source/js/activities/servicesOverview.js
@@ -17,8 +17,6 @@ var A = Activity.extend(function ServicesOverviewActivity() {
         backLink: '/marketplaceProfile', helpLink: this.viewModel.helpLink
     });
     
-    this.defaultNavBar = this.navBar.model.toPlainObject(true);
-    
     // On changing jobTitleID:
     // - load job title name
     this.registerHandler({
@@ -88,14 +86,6 @@ var A = Activity.extend(function ServicesOverviewActivity() {
 
 exports.init = A.init;
 
-A.prototype.updateNavBarState = function updateNavBarState() {
-    
-    if (!this.app.model.onboarding.updateNavBar(this.navBar)) {
-        // Reset
-        this.navBar.model.updateWith(this.defaultNavBar, true);
-    }
-};
-
 A.prototype.show = function show(state) {
     // Reset
     this.viewModel.jobTitleID(null);
@@ -103,8 +93,6 @@ A.prototype.show = function show(state) {
     this.viewModel.serviceAttributes.proposedServiceAttributes({});
     
     Activity.prototype.show.call(this, state);
-    
-    this.updateNavBarState();
     
     var params = state && state.route && state.route.segments;
     var jid = params[0] |0;
@@ -121,7 +109,6 @@ var UserJobProfile = require('../viewmodels/UserJobProfile');
 function ViewModel(app) {
     this.helpLink = '/help/relatedArticles/201967766-describing-your-services-to-clients';
 
-    this.isInOnboarding = app.model.onboarding.inProgress;
     this.jobTitleID = ko.observable(0);
     
     this.isLoadingUserJobTitle = ko.observable(false);
@@ -170,13 +157,11 @@ function ViewModel(app) {
     
     this.submitText = ko.pureComputed(function() {
         return (
-            app.model.onboarding.inProgress() ?
-                'Save and continue' :
-                this.isLoading() ? 
-                    'loading...' : 
-                    this.isSaving() ? 
-                        'saving...' : 
-                        'Save'
+            this.isLoading() ?
+                'loading...' :
+                this.isSaving() ?
+                    'saving...' :
+                    'Save'
         );
     }, this);
     
@@ -211,15 +196,8 @@ function ViewModel(app) {
 
                 // Cleanup
                 this.serviceAttributes.proposedServiceAttributes({});
-                
-                // Move forward:
-                if (app.model.onboarding.inProgress()) {
-                    // Ensure we keep the same jobTitleID in next steps as here:
-                    app.model.onboarding.selectedJobTitleID(this.jobTitleID());
-                    app.model.onboarding.goNext();
-                } else {
-                    app.successSave();
-                }
+
+                app.successSave();
             }.bind(this))
             .catch(function(err) {
                 this.isSaving(false);

--- a/app/source/js/models/ExperienceLevel.js
+++ b/app/source/js/models/ExperienceLevel.js
@@ -17,4 +17,8 @@ function ExperienceLevel(values) {
     }, values);
 }
 
+ExperienceLevel.prototype.hasExperienceLevel = function() {
+    return this.experienceLevelID() > 0;
+};
+
 module.exports = ExperienceLevel;

--- a/app/source/js/models/PublicUserJobTitle.js
+++ b/app/source/js/models/PublicUserJobTitle.js
@@ -115,6 +115,13 @@ function PublicUserJobTitle(values) {
     this.hasServiceAttributes = function() {
         return !!(this.serviceAttributes() && this.serviceAttributes().hasAttributes());
     };
+
+    /**
+     * @returns true if there is any intro text
+     */
+    this.hasIntro = function() {
+        return !!this.intro();
+    };
 }
 
 module.exports = PublicUserJobTitle;

--- a/app/source/js/models/PublicUserJobTitle.js
+++ b/app/source/js/models/PublicUserJobTitle.js
@@ -108,6 +108,13 @@ function PublicUserJobTitle(values) {
             return !service.isClientSpecific();
         });
     };
+
+    /**
+     * @returns true if there are any service attributes with this job title 
+     */
+    this.hasServiceAttributes = function() {
+        return !!(this.serviceAttributes() && this.serviceAttributes().hasAttributes());
+    };
 }
 
 module.exports = PublicUserJobTitle;

--- a/app/source/js/models/PublicUserJobTitleServiceAttributes.js
+++ b/app/source/js/models/PublicUserJobTitleServiceAttributes.js
@@ -27,4 +27,19 @@ function PublicUserJobTitleServiceAttributes(values) {
     }, values);
 }
 
+/**
+ * @returns true if there are either service attributes or an experience level with this job title
+ */
+PublicUserJobTitleServiceAttributes.prototype.hasAttributes = function() {
+    return this.hasExperienceLevel() || (this.serviceAttributes().length > 0);
+};
+
+/**
+ * @returns true if an experience level has been set for this job title
+ */
+PublicUserJobTitleServiceAttributes.prototype.hasExperienceLevel = function() {
+    return this.experienceLevel() && this.experienceLevel().hasExperienceLevel();
+};
+
+
 module.exports = PublicUserJobTitleServiceAttributes;

--- a/app/source/js/viewmodels/OnboardingProgress.js
+++ b/app/source/js/viewmodels/OnboardingProgress.js
@@ -105,7 +105,6 @@ OnboardingProgress.steps = {
         'welcome',
         'addJobTitles',
         'schedulingPreferences',
-        'servicesOverview',
         'serviceProfessionalService',
         'serviceAddresses',
         'bookingPolicies',
@@ -117,9 +116,6 @@ OnboardingProgress.steps = {
         welcome: {},
         addJobTitles: {},
         schedulingPreferences: {},
-        servicesOverview: {
-            jobTitleSpecific: true
-        },
         serviceProfessionalService: {
             jobTitleSpecific: true
         },

--- a/web/App_Code/LcRest/ExperienceLevel.cs
+++ b/web/App_Code/LcRest/ExperienceLevel.cs
@@ -64,7 +64,7 @@ namespace LcRest
         {
             using (var db = new LcDatabase())
             {
-                return FromDB(db.QuerySingle(sqlGetList, languageID, countryID, experienceLevelID));
+                return FromDB(db.QuerySingle(sqlGetItem, languageID, countryID, experienceLevelID));
             }
         }
         #endregion

--- a/web/_DBUpdate/is392-optional-services-overview - B1 - users-onboarding-data-migration.sql
+++ b/web/_DBUpdate/is392-optional-services-overview - B1 - users-onboarding-data-migration.sql
@@ -1,0 +1,4 @@
+-- servicesOverview is being removed from onboarding sequence
+UPDATE users
+SET OnboardingStep = 'serviceProfessionalService'
+WHERE OnboardingStep = 'servicesOverview';


### PR DESCRIPTION
This PR is for all of the issues in the epic #392. 

Note that there are database changes in this epic: one included in a commit, and the other in #389. 

This PR includes
1. a bug fix for experience level on API
2. Change to the button label for services overview
3. Removing services overview from the onboarding sequence
4. Optionally showing services overview on the profile page

There is an open question in https://github.com/loconomics/loconomics/issues/425 about whether we change the stored procedure for checking for required service attributes.

When this is complete, you can close all of the issues in the epic #392 and the epic itself.