### PR TITLE
Place the hover rules on LI whether hovering or active so there's no …

### DIFF
--- a/app/source/css/components/PageMenu.styl
+++ b/app/source/css/components/PageMenu.styl
@@ -37,19 +37,18 @@
           font-size: 15px;
         }
 
-          &:hover {
-             border-bottom: 4px solid white;
-             padding-bottom: 14px !important;
-           }
-             
-           &.active {
-             a {
-               border-bottom: 4px solid;
-               padding-bottom: 14px !important;
-               outline: none;
-             }  
-           } 
-      } 
+        hover() {
+          border-bottom: 4px solid white;
+          padding-bottom: 14px !important;
+        }
+
+        &:hover {
+          hover()
+        }
+        &.active {
+          hover()
+        }
+      }
     }
     
     @media $mediaMinXs {


### PR DESCRIPTION
Fixes gap on "pages" for the tab navigation links when hovered or active. It was already aligned on the `searchCategory/` section of site and I spot checked and there didn't appear to be any regressions from my code there.

@joshdanielson  @IagoSRL I also noticed on the `searchCategory/` section of site that there's no setting of the `.active` class on those tabs. It looks intentional as it's not really a page jump but just swaps the hero image and cards. But shouldn't it still indicate which section you're on? I was tempted to work on that too, but thought I'd ask first.

In any event, this fixes said tabs.

BEFORE (on production) .. note the gap on hovered tab:
<img width="772" alt="static-pages-before" src="https://cloud.githubusercontent.com/assets/142403/26164291/17a27580-3ae1-11e7-9321-76b4109d3a8c.png">

AFTER (on localhost installation):
<img width="883" alt="static-pages-after" src="https://cloud.githubusercontent.com/assets/142403/26164292/17a6173a-3ae1-11e7-8f43-3b55c013f958.png">
