### PR TITLE
Is409 location forms copy

### DIFF
--- a/app/source/html/activities/addressEditor.html
+++ b/app/source/html/activities/addressEditor.html
@@ -29,10 +29,7 @@
                         </div>
                         <div class="form-group" data-bind="visible: isServiceLocation">
                             <p class="form-control-static">
-                                <span data-bind="visible: city() || stateProvinceCode()">
-                                    <span data-bind="text: city"></span>,
-                                    <span data-bind="text: stateProvinceCode"></span>
-                                </span>
+                                <span data-bind="text: cityState() || 'City:'"></span>
                                 <!-- White space to reserve space -->
                                 &nbsp;
                             </p>

--- a/app/source/html/activities/addressEditor.html
+++ b/app/source/html/activities/addressEditor.html
@@ -17,12 +17,12 @@
                         <span data-bind="text: header"></span>
                         <app-loading-spinner params="mod: 'onRight'"></app-loading-spinner>
                     </h2>
-                    <h3 data-bind="text: subheader"></h3>
+                    <p class="isolated text-muted" data-bind="text: subheader"></p>
                     <div data-bind="with: address()">
                         <div data-bind="visible: isServiceLocation">
-                            <app-unlabeled-input params="placeholder: 'Location name, e.g. ActivSpace Mission', value: addressName, disable: $root.isLocked" data-bind="visible: !$parent.clientUserID()"></app-unlabeled-input>
-                            <app-unlabeled-input params="placeholder: 'Street address line 1', value: addressLine1, disable: $root.isLocked"></app-unlabeled-input>
-                            <app-unlabeled-input params="placeholder: 'Street address line 2', value: addressLine2, disable: $root.isLocked"></app-unlabeled-input>
+                            <app-unlabeled-input params="placeholder: 'Location name, e.g. building or business name', value: addressName, disable: $root.isLocked" data-bind="visible: !$parent.clientUserID()"></app-unlabeled-input>
+                            <app-unlabeled-input params="placeholder: 'Street address', value: addressLine1, disable: $root.isLocked"></app-unlabeled-input>
+                            <app-unlabeled-input params="placeholder: 'Street address line 2 (optional)', value: addressLine2, disable: $root.isLocked"></app-unlabeled-input>
                         </div>
                         <div class="form-group" data-bind="css: { 'has-error': $root.errorMessages.postalCode() }">
                             <input type="number" class="form-control" placeholder="Zip code" aria-label="Zip code" data-bind="textInput: postalCode, disable: $root.isLocked, popover: { content: $root.errorMessages.postalCode(), trigger: 'focus', container: 'body', placement: 'bottom' }">
@@ -44,7 +44,7 @@
                         </div>
                         <div class="form-group" data-bind="visible: isServiceLocation">
                             <label class="sr-only" for="addressEditorSpecialInstructions">Special instructions</label>
-                            <textarea rows="2" class="form-control" placeholder="Any special instructions? (e.g. intercom code, parking, etc.)" id="addressEditorSpecialInstructions" data-bind="textInput: specialInstructions, disable: $root.isLocked"></textarea>
+                            <textarea rows="2" class="form-control" placeholder="Any special instructions for your clients, e.g. intercom code, parking? (optional)" id="addressEditorSpecialInstructions" data-bind="textInput: specialInstructions, disable: $root.isLocked"></textarea>
                         </div>
                     </div>
                     <div class="LightForm-submitBar">

--- a/app/source/html/activities/addressEditor.html
+++ b/app/source/html/activities/addressEditor.html
@@ -17,6 +17,7 @@
                         <span data-bind="text: header"></span>
                         <app-loading-spinner params="mod: 'onRight'"></app-loading-spinner>
                     </h2>
+                    <h3 data-bind="text: subheader"></h3>
                     <div data-bind="with: address()">
                         <div data-bind="visible: isServiceLocation">
                             <app-unlabeled-input params="placeholder: 'Location name, e.g. ActivSpace Mission', value: addressName, disable: $root.isLocked" data-bind="visible: !$parent.clientUserID()"></app-unlabeled-input>

--- a/app/source/html/activities/serviceAddresses.html
+++ b/app/source/html/activities/serviceAddresses.html
@@ -15,10 +15,10 @@
                     <div class="Icon-container">
                         <span class="Tile-icon fa ion ion-ios-location-outline" aria-hidden="true"></span>
                     </div>
-                    <span class="Tile-content">
-                        <h2><span data-bind="visible: isInOnboarding()">Add <span data-bind="text: jobTitleName"></span> service areas/locations</span><span data-bind="visible: !isInOnboarding()"><span data-bind="text: jobTitleName"></span> service areas/locations</span></h2> 
+                    <div class="Tile-content">
+                        <h2>Where do you work as a <span data-bind="text: jobTitleName"></span></h2>
                         <p>Tell clients where you're able to work. Do you work in specific neighborhoods? From an office or a studio? All of the above?</p>
-                    </span>
+                    </div>
                 </div>
                 <h2 class="SectionTitle">
                     <span data-bind="visible: headerText, text: headerText"></span>

--- a/app/source/html/activities/serviceAddresses.html
+++ b/app/source/html/activities/serviceAddresses.html
@@ -11,39 +11,41 @@
             </div>
             <div class="col-md-7 col-sm-reset">
                 <app-onboarding-progress-bar></app-onboarding-progress-bar>
-                <div class="OnboardingValueProp"> 
+                <div class="OnboardingValueProp" data-bind="visible: showSupportingText">
                     <div class="Icon-container">
                         <span class="Tile-icon fa ion ion-ios-location-outline" aria-hidden="true"></span>
                     </div>
                     <div class="Tile-content">
-                        <h2>Where do you work as a <span data-bind="text: jobTitleName"></span></h2>
+                        <h2>Where do you work as a <span data-bind="text: jobTitleName"></span>?</h2>
                         <p>Tell clients where you're able to work. Do you work in specific neighborhoods? From an office or a studio? All of the above?</p>
                     </div>
                 </div>
-                <h2 class="SectionTitle">
-                    <span data-bind="visible: headerText, text: headerText"></span>
-                </h2>
+                <h2 class="SectionTitle" data-bind="visible: headerText, text: headerText"></h2>
                 <div data-bind="css: { 'is-loading': isLoading }">
                     <app-loading-spinner params="mod: 'row bigger'"></app-loading-spinner>
                 </div>
                 <app-job-titles-list params="jobTitles: jobTitles.userJobProfile, selectJobTitle: jobTitles.selectJobTitle" data-bind="visible: jobTitleID() === 0"></app-job-titles-list>
                 <div id="addressesListView">
-                    <div data-bind="template: { name: 'service-addresses-template', data: serviceAddresses }"></div>
+                    <!-- ko if: isInOnboarding --><div data-bind="template: { name: 'service-addresses-open-list-template', data: serviceAddresses }"></div><!-- /ko -->
+                    <!-- ko ifnot: isInOnboarding --><div data-bind="template: { name: 'service-addresses-template', data: serviceAddresses }"></div><!-- /ko -->
                 </div>
+
+                <h2 class="SectionTitle" data-bind="visible: addMoreHeaderText, text: addMoreHeaderText"></h2>
                 <div class="TilesList TilesList--openEnd" data-bind="visible: jobTitleID()">
                     <button type="button" class="CompactLinkTile" data-bind="click: addServiceLocation">
-                        <div class="Tile-content text-muted">Add a service location</div>
+                        <div class="Tile-content text-muted" data-bind="text: addLocationLabel"></div>
                         <div class="Tile-icon text-muted">
                             <span class="fa ion ion-plus"></span>
                         </div>
                     </button>
                     <button type="button" class="CompactLinkTile" data-bind="click: addServiceArea, visible: !serviceAddresses.isSelectionMode()">
-                        <div class="Tile-content text-muted">Add a service area/radius</div>
+                        <div class="Tile-content text-muted" data-bind="text: addAreaLabel"></div>
                         <div class="Tile-icon text-muted">
                             <span class="fa ion ion-plus"></span>
                         </div>
                     </button>
                 </div>
+
                 <div data-bind="visible: clientAddresses.isSelectionMode() && clientAddresses.hasAddresses()">
                     <h2 class="SectionTitle">Select a client location</h2>
                     <div data-bind="template: { name: 'service-addresses-template', data: clientAddresses }"></div>
@@ -56,6 +58,7 @@
                         </div>
                     </button>
                 </div>
+
                 <div class="isolated inset" data-bind="visible: onboardingNextReady() && jobTitleID() !== 0">
                     <button type="button" class="btn btn-primary btn-block" data-bind="click: goNext">Save and continue</button>
                 </div>

--- a/app/source/html/templates/service-addresses.html
+++ b/app/source/html/templates/service-addresses.html
@@ -1,16 +1,26 @@
 <!-- Knockout Template service-addresses -->
+<!-- service address template with closed list classes -->
 <script type="text/html" id="service-addresses-template">
-    <ul class="TilesList" data-bind="foreach: addresses">
-        <li><a class="ItemAddonTile" href="#" data-bind="click: $parent.selectAddress, css: { active: $parent.observerSelected($data) }">
-            <i class="Tile-marker fa ion ion-ios-location-outline" aria-hidden="true"></i>
-            <div class="Tile-content">
-                <div data-bind="text: addressName() || 'Service Area'"></div>
-                <em data-bind="text: singleLine"></em>
-            </div>
-            <div class="Tile-addon" aria-hidden="true">
-                <span class="fa fa-xl ion ion-ios-circle-outline" aria-hidden="true"
-                      data-bind="css: { 'ion-ios-arrow-right': !$parent.isSelectionMode(), 'ion-ios-circle-filled': $parent.isSelectionMode() && $parent.observerSelected($data), 'ion-ios-circle-outline': $parent.isSelectionMode() && !$parent.observerSelected($data)() }"></span>
-            </div>
-        </a></li>
+    <ul class="TilesList" data-bind="foreach: {data: addresses, as: 'address'}">
+        <li data-bind="template: { name: 'service-addresses-list-item-template', data: { address: address, viewModel: $parent} }"></li>
     </ul>
+</script>
+<!-- service address template with open list classes -->
+<script type="text/html" id="service-addresses-open-list-template">
+    <ul class="TilesList TilesList--openEnd" data-bind="foreach: {data: addresses, as: 'address'}">
+        <li data-bind="template: { name: 'service-addresses-list-item-template', data: { address: address, viewModel: $parent} }"></li>
+    </ul>
+</script>
+<script type="text/html" id="service-addresses-list-item-template">
+    <a class="ItemAddonTile" href="#" data-bind="click: function(data, event) { viewModel.selectAddress(data.address, event) }, css: { active: viewModel.observerSelected(address) }">
+        <i class="Tile-marker fa ion ion-ios-location-outline" aria-hidden="true"></i>
+        <div class="Tile-content" data-bind="with: address">
+            <div data-bind="text: addressName() || 'Service Area'"></div>
+            <em data-bind="text: singleLine"></em>
+        </div>
+        <div class="Tile-addon" aria-hidden="true">
+              <span class="fa fa-xl ion ion-ios-circle-outline" aria-hidden="true"
+                  data-bind="css: { 'ion-ios-arrow-right': !viewModel.isSelectionMode(), 'ion-ios-circle-filled': viewModel.isSelectionMode() && viewModel.observerSelected(address), 'ion-ios-circle-outline': viewModel.isSelectionMode() && !viewModel.observerSelected(address)() }"></span>
+        </div>
+    </a>
 </script>

--- a/app/source/js/activities/addressEditor.js
+++ b/app/source/js/activities/addressEditor.js
@@ -158,13 +158,14 @@ A.prototype.show = function show(options) {
             case 'serviceArea':
                 this.viewModel.address().isServiceArea(true);
                 this.viewModel.address().isServiceLocation(false);
-                this.viewModel.header('Add a service area');
+                this.viewModel.header('Add an area where you work');
+                this.viewModel.subheader('Clients will be able to book your offerings at locations within this area.');
                 break;
             case 'serviceLocation':
                 this.viewModel.address().isServiceArea(false);
                 this.viewModel.address().isServiceLocation(true);
                 this.viewModel.header('Add a place where you work');
-                this.viewModel.subheader('Clients will be able to book your offerings at this location');
+                this.viewModel.subheader('Clients will be able to book your offerings at this location.');
                 break;
             case 'clientLocation':
                 // A service professional is adding a location to perform a service that belongs

--- a/app/source/js/activities/addressEditor.js
+++ b/app/source/js/activities/addressEditor.js
@@ -126,8 +126,13 @@ A.prototype.show = function show(options) {
         .then(function (addressVersion) {
             if (addressVersion) {
                 this.viewModel.addressVersion(addressVersion);
-                this.viewModel.header('Edit location');
-            } else {
+
+                var address = addressVersion.original,
+                    header = (address.isServiceLocation() && address.kind() == Address.kind.service) ? 'Place of work' : 'Edit location';
+
+                this.viewModel.header(header);
+            }
+            else {
                 this.viewModel.addressVersion(null);
                 this.viewModel.header('Unknown or deleted location');
             }
@@ -147,18 +152,19 @@ A.prototype.show = function show(options) {
             jobTitleID: jobTitleID
         }));
 
+        this.viewModel.subheader('');
+
         switch (serviceType) {
             case 'serviceArea':
                 this.viewModel.address().isServiceArea(true);
                 this.viewModel.address().isServiceLocation(false);
                 this.viewModel.header('Add a service area');
-                this.viewModel.subheader('');
                 break;
             case 'serviceLocation':
                 this.viewModel.address().isServiceArea(false);
                 this.viewModel.address().isServiceLocation(true);
                 this.viewModel.header('Add a place where you work');
-                this.viewModel.subheader('Clients will be able to book your offerings at this place');
+                this.viewModel.subheader('Clients will be able to book your offerings at this location');
                 break;
             case 'clientLocation':
                 // A service professional is adding a location to perform a service that belongs
@@ -167,13 +173,11 @@ A.prototype.show = function show(options) {
                 this.viewModel.address().isServiceArea(false);
                 this.viewModel.address().isServiceLocation(true);
                 this.viewModel.header('Add a client location');
-                this.viewModel.subheader('');
                 break;
             default:
                 this.viewModel.address().isServiceArea(true);
                 this.viewModel.address().isServiceLocation(true);
                 this.viewModel.header('Add a location');
-                this.viewModel.subheader('');
                 break;
         }
     }

--- a/app/source/js/activities/addressEditor.js
+++ b/app/source/js/activities/addressEditor.js
@@ -131,6 +131,8 @@ A.prototype.show = function show(options) {
                 this.viewModel.addressVersion(null);
                 this.viewModel.header('Unknown or deleted location');
             }
+
+            this.viewModel.subheader('');
         }.bind(this))
         .catch(function (err) {
             this.app.modals.showError({
@@ -150,11 +152,13 @@ A.prototype.show = function show(options) {
                 this.viewModel.address().isServiceArea(true);
                 this.viewModel.address().isServiceLocation(false);
                 this.viewModel.header('Add a service area');
+                this.viewModel.subheader('');
                 break;
             case 'serviceLocation':
                 this.viewModel.address().isServiceArea(false);
                 this.viewModel.address().isServiceLocation(true);
-                this.viewModel.header('Add a service location');
+                this.viewModel.header('Add a place where you work');
+                this.viewModel.subheader('Clients will be able to book your offerings at this place');
                 break;
             case 'clientLocation':
                 // A service professional is adding a location to perform a service that belongs
@@ -163,11 +167,13 @@ A.prototype.show = function show(options) {
                 this.viewModel.address().isServiceArea(false);
                 this.viewModel.address().isServiceLocation(true);
                 this.viewModel.header('Add a client location');
+                this.viewModel.subheader('');
                 break;
             default:
                 this.viewModel.address().isServiceArea(true);
                 this.viewModel.address().isServiceLocation(true);
                 this.viewModel.header('Add a location');
+                this.viewModel.subheader('');
                 break;
         }
     }
@@ -180,6 +186,7 @@ function ViewModel(app) {
     this.isInOnboarding = app.model.onboarding.inProgress;
 
     this.header = ko.observable('Edit location');
+    this.subheader = ko.observable('');
     
     // List of possible error messages registered
     // by name

--- a/app/source/js/activities/serviceAddresses.js
+++ b/app/source/js/activities/serviceAddresses.js
@@ -248,12 +248,12 @@ function ViewModel(app) {
     }, this);
 
     this.addLocationLabel = ko.pureComputed(function() {
-        return this.isInOnboarding() ? 'Add a place where clients will meet you' :
+        return this.isInOnboarding() ? 'Place clients come to see you' :
                                        'Add a service location';
     }, this);
 
     this.addAreaLabel = ko.pureComputed(function() {
-        return this.isInOnboarding() ? 'Add an area where you can go to clients' :
+        return this.isInOnboarding() ? 'Area where you go to clients' :
                                        'Add a service area/radius';
     }, this);
 

--- a/app/source/js/activities/serviceAddresses.js
+++ b/app/source/js/activities/serviceAddresses.js
@@ -162,12 +162,6 @@ A.prototype.applyOwnNavbarRules = function() {
 };
 
 A.prototype.updateNavBarState = function updateNavBarState() {
-    //jshint maxcomplexity:12
-
-    var itIs = this.viewModel.serviceAddresses.isSelectionMode();
-
-    this.viewModel.headerText(itIs ? 'Select or add a service location' : 'Locations');
-
     // Perform updates that apply this request:
     this.app.model.onboarding.updateNavBar(this.navBar) ||
     this.applyOwnNavbarRules();
@@ -219,13 +213,49 @@ var UserJobProfile = require('../viewmodels/UserJobProfile'),
     ServiceAddresses = require('../viewmodels/ServiceAddresses');
 
 function ViewModel(app) {
+    // jshint maxstatements:70
     this.helpLink = '/help/relatedArticles/201965996-setting-your-service-locations-areas';
 
     this.isInOnboarding = app.model.onboarding.inProgress;
 
     this.serviceAddresses = new ServiceAddresses();
 
-    this.headerText = ko.observable('Locations');
+    this.headerText = ko.pureComputed(function() {
+        if(this.isInOnboarding() && this.serviceAddresses.sourceAddresses().length === 0) {
+            return '';
+        }
+        else if (this.isInOnboarding()) {
+            return 'Locations for your listing';
+        }
+        else if(this.serviceAddresses.isSelectionMode()) {
+            return 'Choose a place for this booking';
+        }
+        else {
+            return 'Locations';
+        }
+    }, this);
+
+    this.addMoreHeaderText = ko.pureComputed(function() {
+        if(this.isInOnboarding() && this.serviceAddresses.sourceAddresses().length === 0) {
+            return 'Add at least one for your listing';
+        }
+        else if (this.isInOnboarding()) {
+            return 'Want to add any more?';
+        }
+        else {
+            return '';
+        }
+    }, this);
+
+    this.addLocationLabel = ko.pureComputed(function() {
+        return this.isInOnboarding() ? 'Add a place where clients will meet you' :
+                                       'Add a service location';
+    }, this);
+
+    this.addAreaLabel = ko.pureComputed(function() {
+        return this.isInOnboarding() ? 'Add an area where you can go to clients' :
+                                       'Add a service area/radius';
+    }, this);
 
     this.jobTitleID = ko.observable(0);
     this.jobTitle = ko.observable(null);
@@ -236,6 +266,10 @@ function ViewModel(app) {
     this.clientAddresses = new ServiceAddresses();
     // The list of client addresses is used only in selection mode
     this.clientAddresses.isSelectionMode(true);
+
+    this.showSupportingText = ko.pureComputed(function() {
+        return !(this.clientAddresses.hasAddresses() || this.serviceAddresses.isSelectionMode());
+    }, this);
 
     this.jobTitleName = ko.observable('Job Title');
     this.jobTitles = new UserJobProfile(app);

--- a/app/source/js/models/Address.js
+++ b/app/source/js/models/Address.js
@@ -30,17 +30,18 @@ function Address(values) {
         updatedDate: null, // Autofilled by server
         kind: '' // Autofilled by server
     }, values);
-    
+
+    var joinList = function(list, separator) {
+        return list.filter(function(v) { return !!v; }).join(separator);
+    };
+
     this.singleLine = ko.computed(function() {
-        
-        var list = [
-            this.addressLine1(),
-            this.city(),
-            this.postalCode(),
-            this.stateProvinceCode()
-        ];
-        
-        return list.filter(function(v) { return !!v; }).join(', ');
+        return joinList([
+                this.addressLine1(),
+                this.city(),
+                this.postalCode(),
+                this.stateProvinceCode()
+            ], ', ');
     }, this);
 
     this.singleLineDetailed = ko.pureComputed(function() {
@@ -58,23 +59,28 @@ function Address(values) {
         r += (this.specialInstructions() ? ' (' + this.specialInstructions() + ')' : '');
         return r;
     }, this);
-    
+
     this.addressLine = ko.computed(function() {
-        var list = [
-            this.addressLine1(),
-            this.addressLine2()
-        ];        
-        return list.filter(function(v) { return !!v; }).join(', ');
+        return joinList([
+                this.addressLine1(),
+                this.addressLine2()
+            ], ', ');
+    }, this);
+
+    this.cityState = ko.computed(function() {
+        return joinList([
+                this.city(),
+                this.stateProvinceCode()
+            ], ', ');
     }, this);
     
     this.cityStateLine = ko.computed(function() {
-        var list = [
-            this.city(),
-            this.stateProvinceCode(),
-            this.postalCode()
-        ];
-        return list.filter(function(v) { return !!v; }).join(', ');
-    }, this);    
+        return joinList([
+                this.city(),
+                this.stateProvinceCode(),
+                this.postalCode()
+            ], ', ');
+    }, this);
     
     // TODO: needed? l10n? must be provided by server side?
     var countries = {

--- a/app/source/test/models/Address.spec.js
+++ b/app/source/test/models/Address.spec.js
@@ -1,0 +1,95 @@
+var Address = require('../../js/models/Address');
+
+describe('models/Address', function() {
+    var fullAddress = {
+            addressLine1: '850 Mission St.',
+            addressLine2: 'Ste. 34',
+            postalCode: '94110',
+            city: 'San Francisco',
+            stateProvinceCode: 'CA',
+        };
+
+    describe('singleLine', function() {
+        it('should be empty if all are empty', function() {
+            var a = new Address();
+
+            expect(a.singleLine()).to.equal('');
+        });
+
+        it('should include one item if all others are empty', function() {
+            var tokyo = 'Tokyo',
+                a = new Address({city: tokyo});
+
+            expect(a.singleLine()).to.equal(tokyo);
+        });
+
+        it('should include address line 1, city, postal code, and state/province code', function() {
+            var a = new Address(fullAddress);
+
+            expect(a.singleLine()).to.equal('850 Mission St., San Francisco, 94110, CA');
+        });
+    }); // singleLine
+
+    describe('addressLine', function() {
+        it('should be empty if all are empty', function() {
+            var a = new Address();
+
+            expect(a.addressLine()).to.equal('');
+        });
+
+        it('should include one item if all others are empty', function() {
+            var addressLine1 = '800 80th St',
+                a = new Address({ addressLine1: addressLine1 });
+
+            expect(a.addressLine()).to.equal(addressLine1);
+        });
+
+        it('it should separate address lines with a comma', function() {
+            var a = new Address({ addressLine1: '800 80th St', addressLine2: 'Apt 3' });
+
+            expect(a.addressLine()).to.equal('800 80th St, Apt 3');
+        });
+    }); // addressLine
+
+    describe('cityState', function() {
+        it('should be empty when both are empty', function() {
+            var a = new Address();
+
+            expect(a.cityState()).to.equal('');
+        });
+
+        it('should only include a city only if state is missing', function() {
+            var tokyo = 'Tokyo',
+                a = new Address({city: tokyo});
+
+            expect(a.cityState()).to.equal(tokyo);
+        });
+
+        it('it should separate city and state with a comma', function() {
+            var a = new Address(fullAddress);
+
+            expect(a.cityState()).to.equal('San Francisco, CA');
+        });
+    }); // cityState
+
+    describe('cityStateLine', function() {
+        it('should be empty when all are empty', function() {
+            var a = new Address();
+
+            expect(a.cityStateLine()).to.equal('');
+        });
+
+        it('should only include one if the others are missing', function() {
+            var tokyo = 'Tokyo',
+                a = new Address({city: tokyo});
+
+            expect(a.cityStateLine()).to.equal(tokyo);
+        });
+
+        it('it should separate city, state, and postal code with a comma', function() {
+            var a = new Address(fullAddress);
+
+            expect(a.cityStateLine()).to.equal('San Francisco, CA, 94110');
+        });
+    }); // cityStateLine
+});


### PR DESCRIPTION
This PR covers #406, #407, and #408. They are all child stories under the epic #409.

Note: this is the first commit to actually use tests! Test with ``grunt tests``.

I modified copy on the service addresses template and the address editor template.

I'm mostly using the new language only during onboarding because in that case, the activity is creating items _for the future_, rather than in the moment (e.g., selecting for a booking). 

I altered the service addresses templates because in some cases we want the tile list to be open-ended. 

(For the future: the high number of IF statements in this view model indicate that it's a good example for being broken into several different activities and view models with shared components.)