### PR TITLE
Is492 refactor message bar component

### DIFF
--- a/app/source/css/components/Activity.styl
+++ b/app/source/css/components/Activity.styl
@@ -24,15 +24,6 @@ Activity() {
     @media $media-big-navbar {
         top: $big-navbar-height;
     }
-
-    // bump the activity down further if there's a visible app message bar
-    &.Activity--hasMessageBar {
-        top: $app-navbar-message-bar-height;
-
-        @media $media-big-navbar {
-            top: $big-navbar-message-bar-height;
-        }
-    }
 }
 
 .Activity,

--- a/app/source/css/components/MessageBar.styl
+++ b/app/source/css/components/MessageBar.styl
@@ -1,16 +1,26 @@
 /*
-  TODO: new description
+  Message bar component. Fixed message above the activity, but below navigation.
+
+  Used with app-message-bar component.
 */
 
 $app-message-bar-height = $app-navbar-height
 $big-message-bar-height = $big-navbar-height
 
+/*
+  Spacer included at the top of an activity. Pushes content down the height
+  of the MessageBar, but doesn't require Activity element to be modified.
+*/
 .MessageBarSpacer
     height: $app-message-bar-height
 
     @media $media-big-navbar
         height: $big-message-bar-height
 
+/*
+  Due to absolute position of Activity and nav bar, this must be a child of 
+  body the element and is absolutely positioned just below the nav.
+*/
 .MessageBar
     background-color: $brand-primary-background
     border-bottom-width: 1px

--- a/app/source/css/components/MessageBar.styl
+++ b/app/source/css/components/MessageBar.styl
@@ -1,41 +1,43 @@
 /*
-  Common app-wide message bar fixed below the navigation.
-
-  It is outside the activity element. Its top position depends on 
-  the height of the navigation bar. 
+  TODO: new description
 */
-.AppMessageBarWrapper
+
+$app-message-bar-height = $app-navbar-height
+$big-message-bar-height = $big-navbar-height
+
+.MessageBarSpacer
+    height: $app-message-bar-height
+
+    @media $media-big-navbar
+        height: $big-message-bar-height
+
+.MessageBar
+    background-color: $brand-primary-background
+    border-bottom-width: 1px
+    border-bottom-style: solid
+    border-color: $gray-light
+    height: $app-message-bar-height
     left: 0
-    overflow: visible
     position: absolute
     right: 0
     top: $app-navbar-height
+    width: 100%
     z-index: $app-message-bar-z-index
 
     @media $media-big-navbar
+        border-width: 0
+        height: $big-message-bar-height
         top: $big-navbar-height
 
-    .MessageBar
-        background-color: $brand-primary-background
-        border-bottom-width: 1px
-        border-bottom-style: solid
-        border-color: $gray-light
-        height: $app-message-bar-height
-        width: 100%
+    &.MessageBar--success
+        background-color: $brand-success-background
 
-        &.MessageBar--success
-            background-color: $brand-success-background
+    &.MessageBar--warning
+        background-color: $brand-warning-background
 
-        &.MessageBar--warning
-            background-color: $brand-warning-background
+    p
+        text-align: center
+        line-height: $app-message-bar-height
 
         @media $media-big-navbar
-            border-width: 0
-            height: $big-message-bar-height
-
-        p
-            text-align: center
-            line-height: $app-message-bar-height
-
-            @media $media-big-navbar
-                line-height: $big-message-bar-height
+            line-height: $big-message-bar-height

--- a/app/source/css/utils/styleguideVars.styl
+++ b/app/source/css/utils/styleguideVars.styl
@@ -146,14 +146,8 @@ $grid-gap = round($grid-gutter-width / 2);
 $app-navbar-height = 44px;
 $big-navbar-height = 62px;
 
-$app-message-bar-height = $app-navbar-height;
-$big-message-bar-height = $big-navbar-height;
-
-$app-navbar-message-bar-height = $app-navbar-height + $app-message-bar-height;
-$big-navbar-message-bar-height = $big-navbar-height + $big-message-bar-height;
-
 $app-activity-z-index = 1;
-$app-message-bar-z-index = 1;
+$app-message-bar-z-index = 202;
 
 // Media queries where each one of the navbars are used
 // (this allows to selectively choose on height or another

--- a/app/source/html/activities/profile.html
+++ b/app/source/html/activities/profile.html
@@ -1,11 +1,11 @@
 <!-- Activity profile -->
 <div data-activity="profile" data-bind="css: { 'is-loading': isLoading }">
-    <script type="text/html" id="profile-message-bar-template">
+    <app-message-bar params="editListing: editListing, jobTitle: jobTitleSingularName, isActive: listingIsActive, visible: isMessageBarVisible, tone: messageBarTone">
         <p class="small">
-            <span data-bind="text: jobTitle"></span> listing is <span data-bind="ifnot:isActive">inactive</span><span data-bind="if:isActive">active</span>.
+            <span data-bind="text: jobTitle"></span> listing is <span data-bind="ifnot:isActive">inactive.</span><span data-bind="if:isActive">active.</span>
             <a data-bind="click: editListing" class="btn btn-sm btn-default"><span class="fa ion ion-edit"></span> Edit</a>
         </p>
-    </script>
+    </app-message-bar>
     <app-loading-spinner params="mod: 'xl floating'"></app-loading-spinner>
     <!-- TODO: FROM JUVO, TO REFACTOR -->
     <!-- profile internal menu -->

--- a/app/source/html/parts/AppNav.html
+++ b/app/source/html/parts/AppNav.html
@@ -31,4 +31,3 @@
         </div>
     </div>
 </nav>
-<div class="AppMessageBarWrapper"></div>

--- a/app/source/js/activities/profile.js
+++ b/app/source/js/activities/profile.js
@@ -97,6 +97,7 @@ A.prototype.show = function show(options) {
     Activity.prototype.show.call(this, options);
 
     this.messageBar = new MessageBar({
+        $container: this.$activity,
         templateName: 'profile-message-bar-template',
         tone: MessageBar.tones.warning,
         viewModel: {
@@ -106,7 +107,6 @@ A.prototype.show = function show(options) {
         }
     });
     this.messageBar.setVisible(this.viewModel.isOwnProfile());
-    this.registerMessageBarObserver(this.messageBar.isVisible);
 
     var params = options.route && options.route.segments;
     // Get requested userID or the current user profile
@@ -121,7 +121,6 @@ A.prototype.show = function show(options) {
 A.prototype.hide = function() {
     Activity.prototype.hide.call(this);
 
-    this.disposeMessageBarObserver();
     this.messageBar.dispose();
 };
 

--- a/app/source/js/app-components.js
+++ b/app/source/js/app-components.js
@@ -600,7 +600,7 @@ exports.registerAll = function(app) {
         template: MessageBar.template,
         viewModel: {
             createViewModel: function(params, componentInfo) {
-                return new MessageBar(params, componentInfo.element);
+                return new MessageBar(params, componentInfo.element, componentInfo.templateNodes);
             }
         }
     });

--- a/app/source/js/app-components.js
+++ b/app/source/js/app-components.js
@@ -12,7 +12,8 @@
 var ko = require('knockout'),
     $ = require('jquery'),
     propTools = require('./utils/jsPropertiesTools'),
-    getObservable = require('./utils/getObservable');
+    getObservable = require('./utils/getObservable'),
+    MessageBar = require('./components/MessageBar');
 
 exports.registerAll = function(app) {
     //jshint maxstatements:100
@@ -591,6 +592,15 @@ exports.registerAll = function(app) {
                 }
 
                 return vm;
+            }
+        }
+    });
+
+    ko.components.register('app-message-bar', {
+        template: MessageBar.template,
+        viewModel: {
+            createViewModel: function(params, componentInfo) {
+                return new MessageBar(params, componentInfo.element);
             }
         }
     });

--- a/app/source/js/components/Activity.js
+++ b/app/source/js/components/Activity.js
@@ -283,30 +283,6 @@ Activity.prototype.convertToCancelAction = function convertToCancelAction(action
 };
 
 /**
- * Activities need to accomodate extra space above them when message bars are visible.
- * This function takes an observer indicating when a message bar is visible, and 
- * sets a class on the current activity.
- *
- * To prevent leaking, also call disposeMessageBarObserver
- * 
- * @param {Observer} isVisibleObserver KO observer returning true when a message bar is visible, false otherwise
- */
-Activity.prototype.registerMessageBarObserver = function(isVisibleObserver) {
-    this._messageBarSubscription = isVisibleObserver.subscribe(function(isVisible) {
-        this.$activity.toggleClass('Activity--hasMessageBar', isVisible);
-    }, this);
-};
-
-/**
- * Dispose the subscription to the observer registered in registerMessageBarObserver
- */
-Activity.prototype.disposeMessageBarObserver = function() {
-    if(this._messageBarSubscription) {
-        this._messageBarSubscription.dispose();
-    }
-};
-
-/**
     Singleton helper.
     With the name parameter, a named instance can be created allowing
     several instances per class not being purely 'singleton', more like

--- a/app/source/js/components/MessageBar.js
+++ b/app/source/js/components/MessageBar.js
@@ -19,20 +19,19 @@
 var ko = require('knockout'),
     $ = require('jquery');
 
-var containerSelector = '.AppMessageBarWrapper';
-
 /**
  * Finds and injects template object. Binds the view model to the template.
  * 
  * @private
  */
-var load = function($messageBar, templateName, viewModel) {
-    var $container = $(containerSelector),
-        $template = $('#' + templateName);
+var load = function($container, $messageBarSpacer, $messageBar, templateName, viewModel) {
+    var $template = $('#' + templateName);
 
     $messageBar.html($template.html());
 
-    $container.append($messageBar);
+    $('body').append($messageBar);
+
+    $container.prepend($messageBarSpacer);
 
     ko.applyBindings(viewModel, $messageBar.get(0));
 };
@@ -45,6 +44,7 @@ var load = function($messageBar, templateName, viewModel) {
  * @param options.templateName ID of a knockout template to be used as the message bar
  * @param options.viewModel viewModel for the knockout template
  * @param {MessageBar.tones} options.tone for the message bar when visible
+ * TODO: add container (required!)
  * @constructor
  */
 var MessageBar = function(options) {
@@ -54,13 +54,16 @@ var MessageBar = function(options) {
 
     this.viewModel = options.viewModel || {};
 
+// TODO: I think isVisible can go away now
     this.isVisible = ko.observable(false);
 
+    this._$messageBarSpacer = $('<div>', { 'class': 'MessageBarSpacer' });
     this._$messageBar = $('<div>', { 'class': 'MessageBar' });
+    this._$components = $(this._$messageBarSpacer, this._$messageBar);
 
     this.setTone(options.tone || MessageBar.tones.neutral);
 
-    load(this._$messageBar, templateName, this.viewModel);
+    load(options.$container, this._$messageBarSpacer, this._$messageBar, templateName, this.viewModel);
 };
 
 /**
@@ -111,7 +114,7 @@ MessageBar.prototype.setVisible = function(isVisible) {
  * Makes the message bar visible
  */
 MessageBar.prototype.show = function() {
-    this._$messageBar.show();
+    this._$components.show();
 
     this.isVisible(true);
 };
@@ -120,7 +123,7 @@ MessageBar.prototype.show = function() {
  * Hides the message bar
  */
 MessageBar.prototype.hide = function() {
-    this._$messageBar.hide();
+    this._$components.hide();
 
     this.isVisible(false);
 };
@@ -132,7 +135,7 @@ MessageBar.prototype.hide = function() {
 MessageBar.prototype.dispose = function() {
     this.hide();
 
-    this._$messageBar.remove();
+    this._$components.remove();
 };
 
 module.exports = MessageBar;


### PR DESCRIPTION
@IagoSRL 

I wanted to address #492 before I forgot about everything.

Big changes:
1. The message bar is now a knockout component (``app-message-bar``).
2. It does not modify the Activity JS component, [data-activity] classes or styles

However, the solution is a bit unorthodox.

I wanted ``.MessageBar`` to be ``position: fixed`` within a ``.Activity`` element. While Firefox was rendering this correctly, unfortunately, Chrome was not:

![method-fixed-position](https://user-images.githubusercontent.com/6644016/27462276-67dce5a8-5774-11e7-8f34-7ade82c0b284.png)

Because the navbar is positioned absolutely and ``.Activity`` elements are positioned absolutely, I could not find a way to fix the position of a ``.MessageBar`` without moving the ``.MessageBar`` under ``<body>``.

But, ``app-message-bar`` is a knockout component within the profile activity html. ``components/MessageBar`` moves the ``app-message-bar`` component element _out_ of the activity and underneath ``<body>``. ``MessageBar`` manages that element and moves it back into the activity when the view model is disposed.

Additionally, because I could not modify or re-position the activities, and because ``.MessageBar`` needs vertical space so it does not cover up activity content, the ``app-message-bar`` component also inserts a spacer element into the activity. This spacer pushes content down to create vertical space for the ``.MessageBar``. Thus, the component manages two separate DOM elements, the message bar and a spacer element.

I think this is an improvement on the previous implementation. It's odd, though. If you want to accept the pull request but keep #492 open I understand.