### PR TITLE
fix MessageBar bug raising ko exception

### DIFF
--- a/app/source/js/components/MessageBar.js
+++ b/app/source/js/components/MessageBar.js
@@ -140,8 +140,12 @@ MessageBar.prototype.show = function() {
 MessageBar.prototype.hide = function() {
     this._$parts.hide();
 
-    // Keep the DOM tidy by moving the message bar back into the component
-    this._$component.append(this._$messageBar);
+    // Keep the DOM tidy by temporarily removing the message bar from the DOM
+    // If we insert _$messageBar back into the DOM under the component element,
+    // then ko will try to reapply bindings to the contents of the message bar
+    // when any of the param observables change. This raises an exception because
+    // MessageBar _already_ applied bindings manually in the constructor above.
+    this._$messageBar.detach();
 };
 
 module.exports = MessageBar;


### PR DESCRIPTION
When testing #421 I noticed a knockout exception related to MessageBar. The bug is actually in ``master``. This PR is not associated to an issue.

The issue is that MessageBar manually applies bindings to the component template nodes. When the bar was hidden, those nodes were inserted _back into_ the original component node. Knockout was trying to apply bindings to these nodes a second time, and was throwing an exception as a result. 

The fix: rather than re-inserting the template nodes back under the original component element, we ``detach()`` them from the DOM. We can then insert them back under the ``body`` element as before. When we ``detach()`` them, then ko does not try to re-apply bindings to them.

