### PR TITLE
is481 Clarify language on About Me address form

### DIFF
--- a/app/source/html/templates/contact-info-fieldset.html
+++ b/app/source/html/templates/contact-info-fieldset.html
@@ -15,7 +15,7 @@
             Can receive text messages
         </label>
     </div>
-    <h2 class="SectionTitle">Your address (for our records)</h2>
+    <h2 class="SectionTitle">Your mailing address (for our records)</h2>
     <app-unlabeled-input params="placeholder: 'Street address line 1', value: address.addressLine1, disable: isLocked"></app-unlabeled-input>
     <app-unlabeled-input params="placeholder: 'Street address line 2', value: address.addressLine2, disable: isLocked"></app-unlabeled-input>
     <div class="form-group" data-bind="css: { 'has-error': errorMessages.postalCode() }">
@@ -23,10 +23,7 @@
     </div>
     <div class="form-group">
         <p class="form-control-static">
-            <span data-bind="visible: address.city() || address.stateProvinceCode()">
-                <span data-bind="text: address.city"></span>, 
-                <span data-bind="text: address.stateProvinceCode"></span>
-            </span>
+            <span data-bind="text: address.cityState() || 'City:'"></span>
             <!-- White space to reserve vertical space -->
             &nbsp;
         </p>


### PR DESCRIPTION
Summary of changes:
1. the label
"Your address (for our records)"
now reads
"Your mailing address (for our records)"

2. "City: " label now appears instead of empty space 