### PR TITLE
is588 Remove user type selection from generic sign-up

### DIFF
--- a/app/source/html/parts/LargeNavBar.html
+++ b/app/source/html/parts/LargeNavBar.html
@@ -4,20 +4,9 @@
     </div>
     <!-- Anonymous nav -->
     <ul class="LargeNavBar-navBar nav navbar-right" data-bind="visible: isAnonymous()">
-        <li class="dropdown toggle">
-            <a href="#" class="dropdown-toggle btn btn-link" data-toggle="dropdown">Sign up <b class="caret"></b>
+        <li>
+            <a href="/signup/client" class="btn btn-link">Sign up
             </a>
-            <ul class="dropdown-menu Category-menu">
-                <li>
-                    <a href="/signup/service-professional">I'm a local service professional</a>
-                </li>
-                <li>
-                    <a href="/signup/client">I'm a potential client</a>
-                </li>
-                <li>
-                    <a href="/signup/service-professional">I'm both</a>
-                </li>
-            </ul>
         </li>
         <li>
             <a href="/login" class="btn btn-link">Log in</a>

--- a/app/source/html/parts/UserMenuContents.html
+++ b/app/source/html/parts/UserMenuContents.html
@@ -7,23 +7,14 @@
 <li data-bind="visible: isAnonymous, css: cssIfActive('login')">
     <a href="/login">Log in</a>
 </li>
+<li data-bind="visible: isAnonymous, css: cssIfActive('signup')">
+    <a href="/signup/client">Sign up</a>
+</li>
 <li data-bind="visible: isAnonymous, css: cssIfActive('home-hiw')">
     <a href="/home/home-hiw">How it works</a>
 </li>
 <li data-bind="visible: isAnonymous, css: cssIfActive('help')" class="go-help">
     <a href="/help">Help</a>
-</li>
-<li>
-    <h4 class="App-menus-group-header" data-bind="visible: isAnonymous">SIGN UP</h4>
-</li>
-<li data-bind="visible: isAnonymous, css: cssIfActive('coop-hiw')">
-    <a href="/learnMoreProfessionals/coop-hiw">I'm a local service professional</a>
-</li>
-<li data-bind="visible: isAnonymous, css: cssIfActive('signup')">
-    <a href="/signup/client">I'm a potential client</a>
-</li>
-<li data-bind="visible: isAnonymous, css: cssIfActive('coop-hiw')">
-    <a href="/learnMoreProfessionals/coop-hiw">I'm both</a>
 </li>
 <li data-bind="visible: isInOnboarding() && isServiceProfessional()" class="go-dashboard">
     <a href="#!/help/articles/214880503-take-a-tour" target="_blank"><i class="fa fa-fw ion-map" aria-hidden="true"></i> Take a tour</a>


### PR DESCRIPTION
Summary of changes:
Home page sign up dropdown is now a regular link pointing to /signup/client
Mobile menu has 'Sign up' instead of multiple user based links

@joshdanielson Let me know if you prefer a different spot for the 'Sign up' link in the mobile menu

![newmobilemenu](https://user-images.githubusercontent.com/1480837/28806259-ce6eff7c-7623-11e7-8c5f-a5a8ca4939f2.png)
